### PR TITLE
clean show listing page style

### DIFF
--- a/app/assets/stylesheets/pages/_show.scss
+++ b/app/assets/stylesheets/pages/_show.scss
@@ -4,6 +4,6 @@
   border-radius: 12px;
 }
 
-h2 {
-  font-weight: 600;
+.listing-show-text {
+  color: black;
 }

--- a/app/views/bookings/_form.html.erb
+++ b/app/views/bookings/_form.html.erb
@@ -2,7 +2,7 @@
     <%# need an address attribute for listing %>
     <div class="form-wrapper">
       <div class="rate-container">
-        <p><%= "$" %><%= @equipment_listing.hourly_rate %><%= " hour" %></p>
+        <p class="fw-bold fs-3"><%= "$" %><%= @equipment_listing.hourly_rate %><%= " hour" %></p>
       </div>
         <%= simple_form_for [ @equipment_listing, @booking ] do |f| %>
         <%= f.datetime_field :book_from, class: "btn-input" %>

--- a/app/views/equipment_listings/show.html.erb
+++ b/app/views/equipment_listings/show.html.erb
@@ -13,16 +13,19 @@
           <% if @equipment_listing.photo.key.nil? %>
             <%= "No Image available yet" %>
           <% else %>
-         <%= cl_image_tag @equipment_listing.photo.key, height: 500, width: 1270, crop: :fill %>
+         <%= cl_image_tag @equipment_listing.photo.key, height: 500, width: 1270, crop: :fill, id: "show-page-image" %>
           <% end %>
         </div>
       </div>
       <div class="d-flex">
         <div class="flex-fill">
-          <div class="card-title p-3">
-            <h2><%= @equipment_listing.name %></h2>
+          <div class="card-title pt-3">
+            <h2 class="fw-bold"><%= @equipment_listing.name %></h2>
           </div>
-          <div class="card-subtitle mb-2 status">
+          <div class="card-title border-bottom">
+            <p class="fs-7 fst-italic"><%= @equipment_listing.address %></p>
+          </div>
+          <div class="listing-show-text card-subtitle status pt-4">
             <p><%= @equipment_listing.description %></p>
           </div>
         </div>

--- a/app/views/equipment_listings/show.html.erb
+++ b/app/views/equipment_listings/show.html.erb
@@ -18,7 +18,7 @@
         </div>
       </div>
       <div class="d-flex">
-        <div class="flex-fill">
+        <div class="flex-fill mx-4">
           <div class="card-title pt-3">
             <h2 class="fw-bold"><%= @equipment_listing.name %></h2>
           </div>
@@ -26,7 +26,7 @@
             <p class="fs-7 fst-italic"><%= @equipment_listing.address %></p>
           </div>
           <div class="listing-show-text card-subtitle status pt-4">
-            <p><%= @equipment_listing.description %></p>
+            <p class="fs-5"><%= @equipment_listing.description %></p>
           </div>
         </div>
      <%= render "bookings/form", booking: @booking %>


### PR DESCRIPTION
- cleaned the style of the equipment_listings#show -- added border radius to image, showed address under name of listing, changed color or description, and made price in the booking form bigger

Here how it looks now:

![image](https://user-images.githubusercontent.com/101692280/181871902-12a80a6c-6359-41ef-9da0-b0bc11ab002f.png)
